### PR TITLE
project relative include paths

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -12,7 +12,8 @@
 
 import shlex
 from SublimeLinter.lint import Linter, persist
-
+import sublime
+import os
 
 class Clang(Linter):
 
@@ -56,6 +57,15 @@ class Clang(Linter):
         result += settings.get('extra_flags', '')
 
         include_dirs = settings.get('include_dirs', [])
+
+        src_path = os.path.dirname(self.filename)
+        proj_path = os.path.dirname(sublime.active_window().project_file_name())
+        rel_path = os.path.relpath(proj_path, src_path)
+        # print(src_path)
+        # print(proj_path)
+        # print(rel_path)
+        include_dirs = [rel_path + '/' + i for i in include_dirs]
+        # print(include_dirs)
 
         if include_dirs:
             result += ' '.join([' -I ' + shlex.quote(include) for include in include_dirs])

--- a/linter.py
+++ b/linter.py
@@ -64,11 +64,7 @@ class Clang(Linter):
             src_path = os.path.dirname(self.filename)
             proj_path = os.path.dirname(proj_file)
             rel_path = os.path.relpath(proj_path, src_path)
-            # print(src_path)
-            # print(proj_path)
-            # print(rel_path)
             include_dirs = [os.path.join(rel_path, i) for i in include_dirs]
-            # print(include_dirs)
 
         if include_dirs:
             result += ' '.join([' -I ' + shlex.quote(include) for include in include_dirs])

--- a/linter.py
+++ b/linter.py
@@ -58,14 +58,17 @@ class Clang(Linter):
 
         include_dirs = settings.get('include_dirs', [])
 
-        src_path = os.path.dirname(self.filename)
-        proj_path = os.path.dirname(sublime.active_window().project_file_name())
-        rel_path = os.path.relpath(proj_path, src_path)
-        # print(src_path)
-        # print(proj_path)
-        # print(rel_path)
-        include_dirs = [rel_path + '/' + i for i in include_dirs]
-        # print(include_dirs)
+        # make include paths relative to project file (if it exitst)
+        proj_file = sublime.active_window().project_file_name()
+        if proj_file:
+            src_path = os.path.dirname(self.filename)
+            proj_path = os.path.dirname(proj_file)
+            rel_path = os.path.relpath(proj_path, src_path)
+            # print(src_path)
+            # print(proj_path)
+            # print(rel_path)
+            include_dirs = [rel_path + '/' + i for i in include_dirs]
+            # print(include_dirs)
 
         if include_dirs:
             result += ' '.join([' -I ' + shlex.quote(include) for include in include_dirs])

--- a/linter.py
+++ b/linter.py
@@ -67,7 +67,7 @@ class Clang(Linter):
             # print(src_path)
             # print(proj_path)
             # print(rel_path)
-            include_dirs = [rel_path + '/' + i for i in include_dirs]
+            include_dirs = [os.path.join(rel_path, i) for i in include_dirs]
             # print(include_dirs)
 
         if include_dirs:


### PR DESCRIPTION
Source files in subfolders always use the same project relative include paths.
The include paths are defined in the project file so it is reasonable to use it as a path-reference.
