### PR TITLE
Make the plugin work in C++11 setting. Needs to set extra flags by user.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Clang(Linter):
 
     """Provides an interface to clang."""
 
-    syntax = ('c', 'c improved', 'c++')
+    syntax = ('c', 'c improved', 'c++', 'c++11')
     executable = 'clang'
 
     # We are missing out on some errors by ignoring multiline messages.


### PR DESCRIPTION
Useful since sublime 3 has different highlighters for c++ and c++11, but the linter doesn't try to work with c++ 11.
