### PR TITLE
add language-specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ In addition to the standard SublimeLinter settings, SublimeLinter-clang provides
 |:------|:----------|
 |include_dirs|A list of directories to be added to the header search paths (-I is not needed).|
 |extra_flags|A string with extra flags to pass to clang. These should be used carefully, as they may cause linting to fail.|
+|extra_cflags|A string with extra flags to pass to clang when linting C syntax code.|
+|extra_cxxflags|A string with extra flags to pass to clang when linting C++ syntax code.|
 
-In project-specific settings, '$project_folder' or '${project_folder}' can be used to specify relative path.
+In project-specific settings, '$project_folder' or '${project_folder}' can be used to specify a relative path for the `include_dirs` or `extra_flags` options.
 ```
 "SublimeLinter":
 {
@@ -43,6 +45,8 @@ In project-specific settings, '$project_folder' or '${project_folder}' can be us
     {
         "clang": {
             "extra_flags": "-Wall -I${project_folder}/foo",
+            "extra_cflags": "-std=gnu99",
+            "extra_cxxflags": "-std=gnu++11",
             "include_dirs": [
                 "${project_folder}/3rdparty/bar/include",
                 "${project_folder}/3rdparty/baz"

--- a/linter.py
+++ b/linter.py
@@ -56,7 +56,9 @@ class Clang(Linter):
 
     defaults = {
         'include_dirs': [],
-        'extra_flags': ""
+        'extra_flags': "",
+        'extra_cflags': "",
+        'extra_cxxflags': ""
     }
 
     base_cmd = (
@@ -74,13 +76,13 @@ class Clang(Linter):
         """
 
         result = self.base_cmd
+        settings = self.get_view_settings()
 
         if persist.get_syntax(self.view) in ['c', 'c improved']:
-            result += ' -x c '
+            result += ' -x c ' + settings.get('extra_cflags', '') + ' '
         elif persist.get_syntax(self.view) in ['c++', 'c++11']:
-            result += ' -x c++ '
+            result += ' -x c++ ' + settings.get('extra_cxxflags', '') + ' '
 
-        settings = self.get_view_settings()
         result += apply_template( settings.get('extra_flags', '') )
 
         include_dirs = settings.get('include_dirs', [])


### PR DESCRIPTION
Options ‘extra_cflags’ and ‘extra_cxxflags’ were added to provide C or
C++ specific flags